### PR TITLE
Add show argument to bs_append.bsplus_accordion()

### DIFF
--- a/R/append.R
+++ b/R/append.R
@@ -29,10 +29,11 @@ bs_append.shiny.tag <- function(tag, ...){
   stop("This shiny.tag is not supported")
 }
 
+#' @param show logical, indicates whether to show content of first panel
 #' @rdname bs_accordion
 #' @export
 #'
-bs_append.bsplus_accordion <- function(tag, title, content, ...){
+bs_append.bsplus_accordion <- function(tag, title, content, show = TRUE, ...){
 
   # characterize the existing accordion
   n_panel <- length(tag$children)
@@ -101,7 +102,7 @@ bs_append.bsplus_accordion <- function(tag, title, content, ...){
   collapse <- bs_set_aria(collapse, labelledby = id_heading)
 
   # if this is the first panel, set it as open (add option to suppress)
-  if (identical(n_panel, 0L)){
+  if (identical(n_panel, 0L) & show){
     collapse <- htmltools::tagAppendAttributes(collapse, class = "in")
   }
 

--- a/man/bs_accordion.Rd
+++ b/man/bs_accordion.Rd
@@ -8,7 +8,8 @@
 \usage{
 bs_accordion(id)
 
-\method{bs_append}{bsplus_accordion}(tag, title, content, ...)
+\method{bs_append}{bsplus_accordion}(tag, title, content, show = TRUE,
+  ...)
 
 \method{bs_set_opts}{bsplus_accordion}(tag, panel_type = "primary",
   use_heading_link = TRUE, ...)
@@ -25,6 +26,8 @@ title for the panel heading}
 
 \item{content}{character (HTML) or \code{htmltools::\link[htmltools]{tagList}},
 content for the panel body}
+
+\item{show}{logical, indicates whether to show content of first panel}
 
 \item{...}{other arguments (not used)}
 


### PR DESCRIPTION
Hey,

I added an argument to `bs_append.bsplus_accordion()`, which suppresses that the first panel of an accordion is always open. I need this for my https://github.com/be-marc/swdt project.