### PR TITLE
Fix keeping old attribs in bs_set_attr()

### DIFF
--- a/R/set_attr.R
+++ b/R/set_attr.R
@@ -126,7 +126,7 @@ bs_set_attr <- function(tag, .prefix = "data", ...){
   names_to_keep <- setdiff(names_existing, names_new)
 
   # keep those attributes
-  tag$attribs <- tag$attribs[names_to_keep]
+  tag$attribs <- tag$attribs[names_existing %in% names_to_keep]
 
   # append these attributes to the tag
   args <- c(list(tag = tag), attributes_bs)


### PR DESCRIPTION
Hello,

Little change to keep previous attributes in a tag in `bs_set_attr()`, especially when the attribute is multiple : 

```r
tag <- tags$div(class = "class1", class = "class2")
tag
# <div class="class1 class2"></div>
tag$attribs
# $class
# [1] "class1"
# 
# $class
# [1] "class2"
```

Old & new behavior : 

```r
tag <- htmltools::tags$div(class = "class1", class = "class2")
## old : class2 is dropped
bsplus:::bs_set_attr(tag, target = "#target")
# <div class="class1" data-target="#target"></div>
## new : class 2 is preserved
bsplus:::bs_set_attr(tag, target = "#target")
# <div class="class1 class2" data-target="#target"></div>
```


It fixes one issue in shinyWidget : https://github.com/dreamRs/shinyWidgets/issues/215
And will solve this one in bsplus : https://github.com/ijlyttle/bsplus/issues/55

Victor