### PR TITLE
Use expect_match vs expect_identical

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: bsplus
 Type: Package
 Title: Adds Functionality to the R Markdown + Shiny Bootstrap Framework
-Version: 0.1.1.9002
+Version: 0.1.1.9003
 Authors@R: c(
     person(
       given = "Ian",

--- a/tests/testthat/test-accordion_sidebar.R
+++ b/tests/testthat/test-accordion_sidebar.R
@@ -54,10 +54,10 @@ acc_sidebar_side <- acc_sidebar[["children"]][[1]]
 acc_sidebar_main <- acc_sidebar[["children"]][[2]]
 
 test_that("constructor with different column-specs", {
-  expect_identical(tagGetAttribute(acc_sidebar_side, "class"),
-                   "col-sm-3 col-sm-offset-1")
-  expect_identical(tagGetAttribute(acc_sidebar_main, "class"),
-                   "col-sm-7 col-sm-offset-1")
+  expect_match(tagGetAttribute(acc_sidebar_side, "class"),
+                   "col-sm-3", fixed = TRUE)
+  expect_match(tagGetAttribute(acc_sidebar_main, "class"),
+                   "col-sm-7", fixed = TRUE)
 })
 
 js_acc_sidebar <- use_bs_accordion_sidebar()


### PR DESCRIPTION
The `shiny` team has found an error while doing a reverse dependency check.

```
> test_check("bsplus")
── 1. Failure: constructor with different column-specs (@test-accordion_sidebar.
tagGetAttribute(acc_sidebar_side, "class") not identical to "col-sm-3 col-sm-offset-1".
1/1 mismatches
x[1]: "col-sm-3 offset-md-1 col-sm-offset-1"
y[1]: "col-sm-3 col-sm-offset-1"

── 2. Failure: constructor with different column-specs (@test-accordion_sidebar.
tagGetAttribute(acc_sidebar_main, "class") not identical to "col-sm-7 col-sm-offset-1".
1/1 mismatches
x[1]: "col-sm-7 offset-md-1 col-sm-offset-1"
y[1]: "col-sm-7 col-sm-offset-1"

══ testthat results  ═══════════════════════════════════════════════════════════
[ OK: 102 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 2 ]
1. Failure: constructor with different column-specs (@test-accordion_sidebar.R#57) 
2. Failure: constructor with different column-specs (@test-accordion_sidebar.R#59) 
```

I believe this change still keeps the intent while allowing `shiny` / `markdown` / `htmltools` some flexibility in the code.

------------

We are aiming to release the week of May 25th. We hope this does not disrupt your package on CRAN.  

Thank you!
\- Barret